### PR TITLE
Maintenance task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,19 @@ jobs:
       matrix:
         version:
           - '1'
+          - '1.6'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,8 @@ version = "0.2.0"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 
 [compat]
-Graphs = "1.4"
-julia = "1"
+Graphs = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SNAPDatasets"
 uuid = "fc66bc1b-447b-53fc-8f09-bc9cfb0b0c10"
 authors = ["JuliaGraphs"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.2.0"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 
 [compat]
-Graphs = "1"
+Graphs = "1.6"
 julia = "1.6"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,12 @@
+using Graphs: SimpleGraph, nv, ne
 using SNAPDatasets
 using Test
 
 @testset "SNAP Datasets" begin
-  @test @inferred "$(loadsnap(:as_caida))" == "{26475, 53381} undirected simple Int64 graph"
+  as_caida = loadsnap(:as_caida)
+  @test as_caida isa SimpleGraph{Int64}
+  @test nv(as_caida) == 26475
+  @test ne(as_caida) == 53381
   @test_throws ErrorException loadsnap()
   @test_throws ErrorException loadsnap(:badsnapxxxxx)
 end


### PR DESCRIPTION
This PR:
- Bumps min Julia version to `v1.6`.
- Bumps min Graphs.jl version to `v1.6.0`.
- Adds the Julia versions `v1.6` and `pre` to the testing workflow.
- Makes tests work again as they did depend on the printed representation of a graph and that representation has changed.
- Bumps the version of this package to `v0.2.1`.